### PR TITLE
Dont remove all cmd

### DIFF
--- a/core/class/calendar.class.php
+++ b/core/class/calendar.class.php
@@ -317,11 +317,9 @@ class calendarCmd extends cmd {
 
 	/*     * *********************Methode d'instance************************* */
 
-	public function dontRemoveCmd() {
-		if (in_array($this->getLogicalId(), array('in_progress', 'add_exclude_date', 'add_include_date'))) {
-			return true;
-		}
-		return false;
+	public function dontRemoveCmd()
+	{
+		return true; // on ne supprime aucune commandes
 	}
 
 	public function postInsert() {


### PR DESCRIPTION
Actuellement, le logicalId des commandes du plugin est présent dans la fonction dontRemoveCmd.

Sortir cette partie permet d'ajouter des commandes et qu'elles ne soient pas supprimées.

Cela n'est pas gênant pour les utilisateurs et apporte un plus pour les quelques utilisateurs qui savent se créer des commandes (ou qui utilisent par exemple mon plugin import2calendar qui ajoute des commandes).

Merci


