### PR TITLE
fix a bug where calculOccurence() would return dates outside the input range when called on an event with includeDates

### DIFF
--- a/core/class/calendar.class.php
+++ b/core/class/calendar.class.php
@@ -843,6 +843,10 @@ class calendar_event {
 		$enddatetime = strtotime(date('Y-m-d 00:00:00', strtotime($this->getEndDate())));
 		$diff_day = floor(($enddatetime - $startdatetime) / 86400);
 		foreach ($includeDate as $date) {
+			/* ignore the included date if outside the range */
+			if ((strtotime($date) > strtotime($_endDate)) || (strtotime($date) < strtotime($_startDate)))  {
+              	continue;
+            }
 			foreach ($return as $value) {
 				if ($value['start'] == $date . ' ' . $initStartTime && $value['end'] == $date . ' ' . $initEndTime) {
 					continue (2);

--- a/core/class/calendar.class.php
+++ b/core/class/calendar.class.php
@@ -843,10 +843,12 @@ class calendar_event {
 		$enddatetime = strtotime(date('Y-m-d 00:00:00', strtotime($this->getEndDate())));
 		$diff_day = floor(($enddatetime - $startdatetime) / 86400);
 		foreach ($includeDate as $date) {
-			/* ignore the included date if outside the range */
-			if ((strtotime($date) > strtotime($_endDate)) || (strtotime($date) < strtotime($_startDate)))  {
-              	continue;
-            }
+			/* if range provided, ignore the included date if outside the range */
+			if (!empty($_endDate) && !empty($_startDate)) {
+				if ((strtotime($date) > strtotime($_endDate)) || (strtotime($date) < strtotime($_startDate)))  {
+              		continue;
+            	}
+			}
 			foreach ($return as $value) {
 				if ($value['start'] == $date . ' ' . $initStartTime && $value['end'] == $date . ' ' . $initEndTime) {
 					continue (2);


### PR DESCRIPTION
## Description
This PR solves the problem where calculOccurrence() would return dates outside the input range when called on an event with includeDates


### Suggested changelog entry

1. do not include in the result of calculOccurence() dates of the event that are outside the input startDate/endDate
2. when an input range is not provided, keep dates included

## Types of changes
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

